### PR TITLE
Fix Aurora Sofle dongle integration

### DIFF
--- a/boards/shields/macroknob/macroknob.dtsi
+++ b/boards/shields/macroknob/macroknob.dtsi
@@ -35,21 +35,21 @@ RC(5,0) RC(5,1)
         >;
     };
 
-    // Aurora Sofle left encoder
+    // Aurora Sofle left encoder (on peripheral, not this dongle)
     left_encoder: left_encoder {
         compatible = "alps,ec11";
         steps = <144>;
-        status = "okay";
+        status = "disabled";
 
         a-gpios = <&pro_micro 16 GPIO_PULL_UP>;
         b-gpios = <&pro_micro 10 GPIO_PULL_UP>;
     };
 
-    // Aurora Sofle right encoder
+    // Aurora Sofle right encoder (on peripheral, not this dongle)
     right_encoder: right_encoder {
         compatible = "alps,ec11";
         steps = <144>;
-        status = "okay";
+        status = "disabled";
 
         a-gpios = <&pro_micro 16 GPIO_PULL_UP>;
         b-gpios = <&pro_micro 10 GPIO_PULL_UP>;

--- a/build.yaml
+++ b/build.yaml
@@ -22,8 +22,8 @@
 include:
   - board: nice_nano_v2
     shield: macroknob
-    snippet: studio-rpc-usb-uart;zmk-usb-logging
-    CMAKE_ARGS: -DCONFIG_ZMK_STUDIO=y
+    snippet: studio-rpc-usb-uart
+    cmake-args: -DCONFIG_ZMK_STUDIO=y
     
   - board: nice_nano_v2
     shield: settings_reset


### PR DESCRIPTION
Disable peripheral encoder nodes to resolve GPIO pin conflicts that prevented the firmware from building. Fix build.yaml cmake-args casing and remove debug logging snippet.